### PR TITLE
Remove unused argument max_length from TimeSeriesBase

### DIFF
--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -25,7 +25,7 @@ template <typename P, typename T = int>
 class TimeSeriesBase : public TimeSeriesInterface<T>
 {
 public:
-    TimeSeriesBase(size_t max_length, Index start_timeindex = 0);
+    TimeSeriesBase(Index start_timeindex = 0);
     Index newest_timeindex();
     Index count_appended_elements();
     Index oldest_timeindex();

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -3,7 +3,7 @@
 
 
 template <typename P, typename T>
-TimeSeriesBase<P, T>::TimeSeriesBase(size_t max_length  __attribute__((unused)), Index start_timeindex)
+TimeSeriesBase<P, T>::TimeSeriesBase(Index start_timeindex)
 {
     start_timeindex_ = start_timeindex;
     oldest_timeindex_ = start_timeindex_;

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -3,7 +3,7 @@
 
 
 template <typename P, typename T>
-TimeSeriesBase<P, T>::TimeSeriesBase(size_t max_length, Index start_timeindex)
+TimeSeriesBase<P, T>::TimeSeriesBase(size_t max_length  __attribute__((unused)), Index start_timeindex)
 {
     start_timeindex_ = start_timeindex;
     oldest_timeindex_ = start_timeindex_;

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -62,7 +62,7 @@ public:
                              bool leader = true,
                              Index start_timeindex = 0)
         : internal::TimeSeriesBase<internal::MultiProcesses, T>(
-              max_length, start_timeindex),
+              start_timeindex),
           indexes_(segment_id + internal::shm_indexes,
                    4,
                    leader,

--- a/include/time_series/time_series.hpp
+++ b/include/time_series/time_series.hpp
@@ -36,8 +36,7 @@ class TimeSeries : public internal::TimeSeriesBase<internal::SingleProcess, T>
 {
 public:
     TimeSeries(size_t max_length, Index start_timeindex = 0)
-        : internal::TimeSeriesBase<internal::SingleProcess, T>(max_length,
-                                                               start_timeindex)
+        : internal::TimeSeriesBase<internal::SingleProcess, T>(start_timeindex)
     {
         this->mutex_ptr_ =
             std::make_shared<internal::Mutex<internal::SingleProcess> >();


### PR DESCRIPTION
## Description
~Suppress warning about unused argument `max_length` which otherwise shows up multiple times during a build.~

Remove the unused argument `max_length` from `TimeSeriesBase`.

## How I Tested

Running demo_time_series and the unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
