### PR TITLE
added no wait option to newest timeindex

### DIFF
--- a/include/time_series/interface.hpp
+++ b/include/time_series/interface.hpp
@@ -32,9 +32,11 @@ template <typename T>
 class TimeSeriesInterface
 {
 public:
-    /*! \brief returns \f$ newest \f$. waits if the time_series is empty.
+    /*! \brief returns \f$ newest \f$ index. If argument wait is true, waits if
+     * the time_series is empty.
+     * If argument wait is false, the it returns -1 if the time series is empty.
      */
-    virtual Index newest_timeindex() = 0;
+    virtual Index newest_timeindex(bool wait = true) = 0;
 
     /*! \brief returns the number of element that has been contained in the
      * queue, i.e.
@@ -97,7 +99,7 @@ public:
     virtual void tag(const Index &timeindex) = 0;
 
     /*! \brief returns the index at which the time series has been tagged.
-     * Returns the newest timeindex if the time series has never been tagged. 
+     * Returns the newest timeindex if the time series has never been tagged.
      */
     virtual Index tagged_timeindex() = 0;
 

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -26,7 +26,7 @@ class TimeSeriesBase : public TimeSeriesInterface<T>
 {
 public:
     TimeSeriesBase(Index start_timeindex = 0);
-    Index newest_timeindex();
+    Index newest_timeindex(bool wait = true);
     Index count_appended_elements();
     Index oldest_timeindex();
     T newest_element();

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -37,14 +37,24 @@ bool TimeSeriesBase<P, T>::has_changed_since_tag()
 }
 
 template <typename P, typename T>
-Index TimeSeriesBase<P, T>::newest_timeindex()
+Index TimeSeriesBase<P, T>::newest_timeindex(bool wait)
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
-    while (newest_timeindex_ < oldest_timeindex_)
+    if (wait)
     {
-        condition_ptr_->wait(lock);
-        read_indexes();
+        while (newest_timeindex_ < oldest_timeindex_)
+        {
+            condition_ptr_->wait(lock);
+            read_indexes();
+        }
+    }
+    else
+    {
+        if (newest_timeindex_ < oldest_timeindex_)
+        {
+            return -1;
+        }
     }
     return newest_timeindex_;
 }

--- a/tests/basic_unit_tests.cpp
+++ b/tests/basic_unit_tests.cpp
@@ -110,6 +110,13 @@ TEST(time_series_ut, basic_newest_element)
     thread2.join();
 }
 
+TEST(time_series_ut, newest_index_no_wait)
+{
+    TimeSeries<int> ts(100);
+    time_series::Index index = ts.newest_timeindex(false);
+    ASSERT_EQ(index, -1);
+}
+
 void *add_element_mp(void *)
 {
     bool clear_on_destruction = false;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

If the time series is empty, the function newest_timeindex waits for a first element to be appended to the series. This pull request adds an optional boolean argument to the function. If this argument is false, then the function will not wait if the series is empty, and will return -1 instead.

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

## How I Tested

I added a corresponding unit test. I ran the demo.

[//]: # "Explain how you tested your changes"


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ x] All new functions/classes are documented and existing documentation is updated according to changes.
- [ x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
