### PR TITLE
Terminate on SIGINT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 find_package(catkin REQUIRED COMPONENTS
   mpi_cmake_modules
   shared_memory
+  signal_handler
   real_time_tools
 )
 search_for_eigen()
@@ -46,7 +47,7 @@ include_directories(
 catkin_package(
   LIBRARIES time_series
   INCLUDE_DIRS include
-  CATKIN_DEPENDS mpi_cmake_modules shared_memory 
+  CATKIN_DEPENDS mpi_cmake_modules shared_memory signal_handler
 )
 
 ###########

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -84,6 +84,9 @@ private:
      * lock is released to prevent the lock from blocking application shut down.
      */
     void monitor_signal();
+
+    //! @brief Throw a ReceivedSignal exception if SIGINT was received.
+    static void throw_if_sigint_received();
 };
 
 #include "base.hxx"

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -5,6 +5,10 @@
 
 #include <chrono>
 #include <cmath>
+#include <thread>
+
+#include <signal_handler/signal_handler.hpp>
+#include <signal_handler/exceptions.hpp>
 
 #include "time_series/interface.hpp"
 #include "time_series/internal/specialized_classes.hpp"
@@ -69,8 +73,19 @@ protected:
     std::shared_ptr<ConditionVariable<P> > condition_ptr_;
     std::shared_ptr<Vector<P, T> > history_elements_ptr_;
     std::shared_ptr<Vector<P, Timestamp> > history_timestamps_ptr_;
+
+private:
+    std::thread signal_monitor_thread_;
+
+    /**
+     * @brief Monitors if SIGINT was received and releases the lock if yes.
+     *
+     * Loops until SIGINT was received.  When this happens, the condition_ptr_
+     * lock is released to prevent the lock from blocking application shut down.
+     */
+    void monitor_signal();
 };
 
 #include "base.hxx"
-}
-}
+}  // namespace internal
+}  // namespace time_series

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -267,9 +267,13 @@ bool TimeSeriesBase<P, T>::is_empty()
 template <typename P, typename T>
 void TimeSeriesBase<P, T>::monitor_signal()
 {
+    constexpr double SLEEP_DURATION_MS = 100;
+
     while (!signal_handler::SignalHandler::has_received_sigint())
     {
-        real_time_tools::Timer::sleep_ms(10);
+        real_time_tools::Timer::sleep_ms(SLEEP_DURATION_MS);
     }
+    // notify to release locks that could otherwise prevent the application from
+    // terminating
     condition_ptr_->notify_all();
 }

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -1,12 +1,14 @@
 // Copyright (c) 2019 Max Planck Gesellschaft
 // Vincent Berenz
 
-// throws an exception if SIGINT is received
-#define TS_THROW_IF_SIGINT                                    \
-    if (signal_handler::SignalHandler::has_received_sigint()) \
-    {                                                         \
-        throw signal_handler::ReceivedSignal(SIGINT);         \
+template <typename P, typename T>
+void TimeSeriesBase<P, T>::throw_if_sigint_received()
+{
+    if (signal_handler::SignalHandler::has_received_sigint())
+    {
+        throw signal_handler::ReceivedSignal(SIGINT);
     }
+}
 
 template <typename P, typename T>
 TimeSeriesBase<P, T>::TimeSeriesBase(Index start_timeindex) : empty_(true)
@@ -55,7 +57,7 @@ Index TimeSeriesBase<P, T>::newest_timeindex(bool wait)
     {
         while (newest_timeindex_ < oldest_timeindex_)
         {
-            TS_THROW_IF_SIGINT;
+            throw_if_sigint_received();
 
             condition_ptr_->wait(lock);
             read_indexes();
@@ -86,7 +88,7 @@ Index TimeSeriesBase<P, T>::oldest_timeindex(bool wait)
     read_indexes();
     if (wait)
     {
-        TS_THROW_IF_SIGINT;
+        throw_if_sigint_received();
 
         while (newest_timeindex_ < oldest_timeindex_)
         {
@@ -125,7 +127,7 @@ T TimeSeriesBase<P, T>::operator[](const Index& timeindex)
 
     while (newest_timeindex_ < timeindex)
     {
-        TS_THROW_IF_SIGINT;
+        throw_if_sigint_received();
 
         condition_ptr_->wait(lock);
         read_indexes();
@@ -151,7 +153,7 @@ Timestamp TimeSeriesBase<P, T>::timestamp_ms(const Index& timeindex)
 
     while (newest_timeindex_ < timeindex)
     {
-        TS_THROW_IF_SIGINT;
+        throw_if_sigint_received();
 
         condition_ptr_->wait(lock);
         read_indexes();
@@ -195,7 +197,7 @@ bool TimeSeriesBase<P, T>::wait_for_timeindex(const Index& timeindex,
         }
         else
         {
-            TS_THROW_IF_SIGINT;
+            throw_if_sigint_received();
             condition_ptr_->wait(lock);
         }
         read_indexes();

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -88,10 +88,10 @@ Index TimeSeriesBase<P, T>::oldest_timeindex(bool wait)
     read_indexes();
     if (wait)
     {
-        throw_if_sigint_received();
-
         while (newest_timeindex_ < oldest_timeindex_)
         {
+            throw_if_sigint_received();
+
             condition_ptr_->wait(lock);
             read_indexes();
         }

--- a/package.xml
+++ b/package.xml
@@ -12,13 +12,14 @@
   <maintainer email="mnaveau@tue.mpg.de">Maximilien Naveau</maintainer>
   <author email="manuel.wuthrich@gmail.com">Manuel Wuthrich</author>
   <maintainer email="manuel.wuthrich@gmail.com">Manuel Wuthrich</maintainer>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <depend> mpi_cmake_modules </depend>
   <depend> shared_memory </depend>
+  <depend> signal_handler </depend>
   <depend> real_time_tools </depend>
-  
+
   <export>
   </export>
 


### PR DESCRIPTION
## Description
To prevent the time series from blocking indefinitely when trying to stop the application with Ctrl+C, add a monitor thread that checks if a SIGINT was received and releases the lock if yes.
Further, add a check in all wait loops and throw an exception if SIGINT is received before the condition is fulfilled (as there is usually no valid return value in this case).

## How I Tested

By running some existing demos that previously blocked on Ctrl+C.

I plan to do a bit more testing before merging (e.g. test on real robot).

## Do not merge before

- [x] https://github.com/machines-in-motion/signal_handler/pull/1
- [x] signal_handler is added to the treep configuration

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
