### PR TITLE
added optional bool wait to oldest_timeindex, added method is_empty

### DIFF
--- a/include/time_series/interface.hpp
+++ b/include/time_series/interface.hpp
@@ -15,6 +15,8 @@ namespace time_series
 typedef long int Index;
 typedef long double Timestamp;
 
+const Index EMPTY = -1;
+
 /**
  * \brief Interface for time series.
  * A time_series implements  \f$ X_{{oldest}:{newest}} \f$ which can
@@ -34,7 +36,8 @@ class TimeSeriesInterface
 public:
     /*! \brief returns \f$ newest \f$ index. If argument wait is true, waits if
      * the time_series is empty.
-     * If argument wait is false, the it returns -1 if the time series is empty.
+     * If argument wait is false and the time series is empty,
+     * returns time_series::EMPTY immediately.
      */
     virtual Index newest_timeindex(bool wait = true) = 0;
 
@@ -45,8 +48,10 @@ public:
     virtual Index count_appended_elements() = 0;
 
     /*! \brief returns \f$ oldest \f$. waits if the time_series is empty.
+     * If argument wait is false and the time series is empty,
+     * returns time_series::EMPTY immediately.
      */
-    virtual Index oldest_timeindex() = 0;
+    virtual Index oldest_timeindex(bool wait = true) = 0;
 
     /*! \brief returns \f$ X_{newest} \f$. waits if the time_series is empty.
      */
@@ -111,5 +116,10 @@ public:
      * to \f$ X_{2:11} \f$.
      */
     virtual void append(const T &element) = 0;
+
+    /*! \brief returns true if no element has ever been appended
+     *  to the time series.
+     */
+    virtual bool is_empty() = 0;
 };
 }

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -28,7 +28,7 @@ public:
     TimeSeriesBase(Index start_timeindex = 0);
     Index newest_timeindex(bool wait = true);
     Index count_appended_elements();
-    Index oldest_timeindex();
+    Index oldest_timeindex(bool wait = false);
     T newest_element();
     T operator[](const Index &timeindex);
     Timestamp timestamp_ms(const Index &timeindex);
@@ -42,6 +42,7 @@ public:
     void tag(const Index &timeindex);
     Index tagged_timeindex();
     void append(const T &element);
+    bool is_empty();
 
 protected:
     // in case of multiprocesses: will be used to keep
@@ -53,6 +54,12 @@ protected:
     Index oldest_timeindex_;
     Index newest_timeindex_;
     Index tagged_timeindex_;
+
+protected:
+    // non shared variable. initialized at true,
+    // and switched to false when an element is observed
+    // in the time series. Used only in the "is_empty" method.
+    bool empty_;
 
 protected:
     // see specialized_classes.hpp for

--- a/tests/basic_unit_tests.cpp
+++ b/tests/basic_unit_tests.cpp
@@ -207,3 +207,23 @@ TEST(time_series_ut, timestamps)
     Timestamp stamp_ms2 = ts.timestamp_ms(index);
     ASSERT_LT(stamp_ms2, stamp_ms + 1);
 }
+
+TEST(time_series_ut, empty)
+{
+    TimeSeries<int> ts(100);
+    ASSERT_TRUE(ts.is_empty());
+    ts.append(10);
+    ASSERT_FALSE(ts.is_empty());
+}
+
+TEST(time_series_ut, multi_processes_empty)
+{
+    clear_memory(SEGMENT_ID);
+    MultiprocessTimeSeries<int> ts1(SEGMENT_ID, 100, true);
+    MultiprocessTimeSeries<int> ts2(SEGMENT_ID, 100, false);
+    ASSERT_TRUE(ts1.is_empty());
+    ASSERT_TRUE(ts2.is_empty());
+    ts1.append(10);
+    ASSERT_FALSE(ts1.is_empty());
+    ASSERT_FALSE(ts2.is_empty());
+}


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- added optional bool "wait" argument to oldest_timeindex method (default to true). This mirror the behavior of the newest_timeindex method
- added constant time_series::Index EMPTY, which is returned by oldest_timeindex and newest_timeindex method if wait is false. newest_timeindex used to returned -1 in this case, which is the value of EMPTY
- added an is_empty method which returns true if no element has ever been added.

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

- added unit test

[//]: # "Explain how you tested your changes"



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [X] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [X] All new functions/classes are documented and existing documentation is updated according to changes.
- [X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
