### PR TITLE
Join signal monitor thread in destructor

### DIFF
--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -30,6 +30,7 @@ class TimeSeriesBase : public TimeSeriesInterface<T>
 {
 public:
     TimeSeriesBase(Index start_timeindex = 0);
+    ~TimeSeriesBase();
     Index newest_timeindex(bool wait = true);
     Index count_appended_elements();
     Index oldest_timeindex(bool wait = false);
@@ -76,6 +77,8 @@ protected:
 
 private:
     std::thread signal_monitor_thread_;
+    //! Set to true in destructor to indicate thread that it should terminate.
+    std::atomic<bool> is_destructor_called_;
 
     /**
      * @brief Monitors if SIGINT was received and releases the lock if yes.


### PR DESCRIPTION
## Description

Make sure the signal monitor thread is terminated and joined in the
destructor to avoid a "terminate called without an active exception"
error.


## How I Tested
By running unit tests and demo.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
