### PR TITLE
Add include for atomic

### DIFF
--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <thread>


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

While I can build locally without error, [Bamboo fails](https://atlas.is.localnet/bamboo/browse/MGC-BE-164/) with 
```
/workspace/software/workspace/src/catkin/core_robotics/time_series/include/time_series/internal/base.hpp:81:23: error: field 'is_destructor_called_' has incomplete type 'std::atomic<bool>'
     std::atomic<bool> is_destructor_called_;
```
I hope that adding the missing include of `atomic` fixes this.  Could this be a version issue (I'm using Ubuntu 18.04 now locally but Bamboo is still using 16.04)?

## How I Tested

Not tested, needs to be merged to see if Bamboo is happy then.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
