### PR TITLE
added static get_max_length for mp time series

### DIFF
--- a/demos/demo_multiprocess_read.cpp
+++ b/demos/demo_multiprocess_read.cpp
@@ -27,9 +27,7 @@ void run()
 
     // warning: any "demo_multiprocess_write" demo running
     // may hang or crash when this process exit
-    bool clean_on_destruction = true;
-
-    TimeSeries ts(SEGMENT_ID, TIMESERIES_SIZE, clean_on_destruction);
+    TimeSeries ts = TimeSeries::create_leader(SEGMENT_ID, TIMESERIES_SIZE);
 
     while (true)
     {

--- a/demos/demo_multiprocess_write.cpp
+++ b/demos/demo_multiprocess_write.cpp
@@ -22,9 +22,7 @@ void run()
     // will do this
     bool clean_on_destruction = false;
 
-    size_t max_length = TIMESERIES::get_max_length(SEGMENT_ID);
-
-    TIMESERIES ts(SEGMENT_ID, max_length, clean_on_destruction);
+    TIMESERIES ts = TIMESERIES::create_follower(SEGMENT_ID);
 
     for (int i = 0; i < 100; i++)
     {

--- a/demos/demo_multiprocess_write.cpp
+++ b/demos/demo_multiprocess_write.cpp
@@ -13,7 +13,6 @@
 #include "time_series/multiprocess_time_series.hpp"
 
 #define SEGMENT_ID "demo_time_series_multiprocess"
-#define TIMESERIES_SIZE 100
 
 typedef time_series::MultiprocessTimeSeries<shared_memory::Item<10>> TIMESERIES;
 
@@ -23,7 +22,9 @@ void run()
     // will do this
     bool clean_on_destruction = false;
 
-    TIMESERIES ts(SEGMENT_ID, TIMESERIES_SIZE, clean_on_destruction);
+    size_t max_length = TIMESERIES::get_max_length(SEGMENT_ID);
+
+    TIMESERIES ts(SEGMENT_ID, max_length, clean_on_destruction);
 
     for (int i = 0; i < 100; i++)
     {

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -31,6 +31,7 @@ class TimeSeriesBase : public TimeSeriesInterface<T>
 {
 public:
     TimeSeriesBase(Index start_timeindex = 0);
+    TimeSeriesBase(TimeSeriesBase<P, T> &&other) noexcept;
     ~TimeSeriesBase();
     Index newest_timeindex(bool wait = true);
     Index count_appended_elements();

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -25,6 +25,22 @@ TimeSeriesBase<P, T>::TimeSeriesBase(Index start_timeindex)
 }
 
 template <typename P, typename T>
+TimeSeriesBase<P, T>::TimeSeriesBase(TimeSeriesBase<P, T>&& other) noexcept
+    : start_timeindex_(other.start_timeindex_),
+      oldest_timeindex_(other.oldest_timeindex_),
+      newest_timeindex_(other.newest_timeindex_),
+      tagged_timeindex_(other.tagged_timeindex_),
+      empty_(other.empty_),
+      is_destructor_called_(false)
+{
+    mutex_ptr_ = std::move(other.mutex_ptr_);
+    condition_ptr_ = std::move(other.condition_ptr_);
+    history_elements_ptr_ = std::move(other.history_elements_ptr_);
+    history_timestamps_ptr_ = std::move(other.history_timestamps_ptr_);
+    signal_monitor_thread_ = std::move(other.signal_monitor_thread_);
+}
+
+template <typename P, typename T>
 TimeSeriesBase<P, T>::~TimeSeriesBase()
 {
     is_destructor_called_ = true;

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -82,6 +82,25 @@ public:
         {
             write_indexes();
         }
+        if (leader)
+        {
+            // sharing the max_length in the shared memory
+            // (follower can query size for proper construction)
+            shared_memory::set<size_t>(segment_id, "max_length", max_length);
+        }
+    }
+
+    /**
+     * returns the max length used by a leading MultiprocessTimeSeries
+     * of the corresponding segment_id
+     */
+    static size_t get_max_length(const std::string& segment_id)
+    {
+        size_t s;
+        {
+            shared_memory::get<size_t>(segment_id, "max_length", s);
+            return s;
+        }
     }
 
 protected:

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -125,6 +125,11 @@ public:
         return index;
     }
 
+    /**
+     * returns a leader instance of MultiprocessTimeSeries<T>
+     * @param segment_id the id of the segment to point to
+     * @param max_length max number of elements in the time series
+     */
     static MultiprocessTimeSeries<T> create_leader(std::string segment_id,
                                                    size_t max_length,
                                                    Index start_timeindex = 0)
@@ -134,6 +139,13 @@ public:
             segment_id, max_length, leader, start_timeindex);
     }
 
+    /**
+     * returns a follower instance of MultiprocessTimeSeries<T>.
+     * An follower instance should be created only if a leader
+     * instance has been created first. A std::runtime_error will
+     * be thrown otherwise.
+     * @param segment_id the id of the segment to point to
+     */
     static MultiprocessTimeSeries<T> create_follower(std::string segment_id)
     {
         bool leader = false;

--- a/tests/test_basic_api.cpp
+++ b/tests/test_basic_api.cpp
@@ -46,6 +46,21 @@ TEST(time_series_ut, basic_multi_processes)
     ASSERT_EQ(value, 30);
 }
 
+TEST(time_series_ut, multi_processes_get_max_length)
+{
+    clear_memory(SEGMENT_ID);
+    {
+        MultiprocessTimeSeries<int> ts1(SEGMENT_ID, 100, true);
+        size_t s = MultiprocessTimeSeries<int>::get_max_length(SEGMENT_ID);
+        ASSERT_EQ(s, 100);
+    }
+    {
+        MultiprocessTimeSeries<int> ts1(SEGMENT_ID, 200, true);
+        size_t s = MultiprocessTimeSeries<int>::get_max_length(SEGMENT_ID);
+        ASSERT_EQ(s, 200);
+    }
+}
+
 TEST(time_series_ut, serialized_multi_processes)
 {
     clear_memory(SEGMENT_ID);


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

A leader and a follower multiprocess time series sharing the same segment_id must "agree" on their size upon construction.
This is error prone. A static get_max_length function has been added, which returns the size used by the leader during its construction, which can be used by follower to setup their own size;


[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

Updated the demo and the unit tests

[//]: # "Explain how you tested your changes"


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] link to dependent pull request

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [X ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [X ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
