### PR TITLE
Add create_*_ptr methods for shared pointers

### DIFF
--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -130,9 +130,10 @@ public:
      * @param segment_id the id of the segment to point to
      * @param max_length max number of elements in the time series
      */
-    static MultiprocessTimeSeries<T> create_leader(std::string segment_id,
-                                                   size_t max_length,
-                                                   Index start_timeindex = 0)
+    static MultiprocessTimeSeries<T> create_leader(
+        const std::string& segment_id,
+        size_t max_length,
+        Index start_timeindex = 0)
     {
         bool leader = true;
         return MultiprocessTimeSeries<T>(
@@ -141,7 +142,9 @@ public:
 
     //! @brief same as create_leader but returning a shared_ptr.
     static std::shared_ptr<MultiprocessTimeSeries<T>> create_leader_ptr(
-        std::string segment_id, size_t max_length, Index start_timeindex = 0)
+        const std::string& segment_id,
+        size_t max_length,
+        Index start_timeindex = 0)
     {
         bool leader = true;
         return std::make_shared<MultiprocessTimeSeries<T>>(
@@ -155,7 +158,8 @@ public:
      * be thrown otherwise.
      * @param segment_id the id of the segment to point to
      */
-    static MultiprocessTimeSeries<T> create_follower(std::string segment_id)
+    static MultiprocessTimeSeries<T> create_follower(
+        const std::string& segment_id)
     {
         bool leader = false;
         Index start_timeindex;
@@ -169,7 +173,7 @@ public:
 
     //! @brief same as create_follower but returning a shared_ptr.
     static std::shared_ptr<MultiprocessTimeSeries<T>> create_follower_ptr(
-        std::string segment_id)
+        const std::string& segment_id)
     {
         bool leader = false;
         Index start_timeindex;

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -139,6 +139,15 @@ public:
             segment_id, max_length, leader, start_timeindex);
     }
 
+    //! @brief same as create_leader but returning a shared_ptr.
+    static std::shared_ptr<MultiprocessTimeSeries<T>> create_leader_ptr(
+        std::string segment_id, size_t max_length, Index start_timeindex = 0)
+    {
+        bool leader = true;
+        return std::make_shared<MultiprocessTimeSeries<T>>(
+            segment_id, max_length, leader, start_timeindex);
+    }
+
     /**
      * returns a follower instance of MultiprocessTimeSeries<T>.
      * An follower instance should be created only if a leader
@@ -151,22 +160,24 @@ public:
         bool leader = false;
         Index start_timeindex;
         size_t max_length;
-        try
-        {
-            start_timeindex =
-                MultiprocessTimeSeries::get_start_timeindex(segment_id);
-            max_length = MultiprocessTimeSeries::get_max_length(segment_id);
-        }
-        catch (shared_memory::Unexpected_size_exception& e)
-        {
-            std::stringstream stream;
-            stream << "failing to create follower multiprocess_time_series "
-                      "with segment_id "
-                   << segment_id << ": "
-                   << "a corresponding leader should be started first";
-            throw std::runtime_error(stream.str());
-        }
+        get_max_length_and_start_index_from_leader(
+            segment_id, &max_length, &start_timeindex);
+
         return MultiprocessTimeSeries<T>(
+            segment_id, max_length, leader, start_timeindex);
+    }
+
+    //! @brief same as create_follower but returning a shared_ptr.
+    static std::shared_ptr<MultiprocessTimeSeries<T>> create_follower_ptr(
+        std::string segment_id)
+    {
+        bool leader = false;
+        Index start_timeindex;
+        size_t max_length;
+        get_max_length_and_start_index_from_leader(
+            segment_id, &max_length, &start_timeindex);
+
+        return std::make_shared<MultiprocessTimeSeries<T>>(
             segment_id, max_length, leader, start_timeindex);
     }
 
@@ -185,6 +196,40 @@ protected:
         indexes_.set(1, this->oldest_timeindex_);
         indexes_.set(2, this->newest_timeindex_);
         indexes_.set(3, this->tagged_timeindex_);
+    }
+
+    /**
+     * @brief Load length and start index from leader.
+     *
+     * Assumes that a leader time series is already running and providing this
+     * information in the shared memory.
+     *
+     * @param[in]  segment_id The id of the segment to point to.
+     * @param[out] max_length The max. length of the time series.
+     * @param[out] start_timeindex
+     * @throws std::runtime_error If the data cannot be read from the specified
+     *     shared memory segment.
+     */
+    static void get_max_length_and_start_index_from_leader(
+        const std::string& segment_id,
+        size_t* max_length,
+        Index* start_timeindex)
+    {
+        try
+        {
+            *start_timeindex =
+                MultiprocessTimeSeries::get_start_timeindex(segment_id);
+            *max_length = MultiprocessTimeSeries::get_max_length(segment_id);
+        }
+        catch (shared_memory::Unexpected_size_exception& e)
+        {
+            std::stringstream stream;
+            stream << "failing to create follower multiprocess_time_series "
+                      "with segment_id "
+                   << segment_id << ": "
+                   << "a corresponding leader should be started first";
+            throw std::runtime_error(stream.str());
+        }
     }
 
     shared_memory::array<Index> indexes_;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

There are some issues with moving an instance into a pointer, so
`std::make_shared<..>(MultiprocessTimeSeries::create_leader(..));` is
currently not working.  Until this is resolved, simply add additional
`create_*_ptr` factories which directly return a shared_ptr.

Move the code to get max_length and start index for the follower to a
separate method to avoid too much duplication.

Changed argument type of segment_id to const reference.

## How I Tested

Running a multi-process demo with simulation of the TriFinger robot.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
