### PR TITLE
added get_raw (serialized) to multiprocess time series

### DIFF
--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -90,8 +90,10 @@ private:
      */
     void monitor_signal();
 
+protected:
     //! @brief Throw a ReceivedSignal exception if SIGINT was received.
     static void throw_if_sigint_received();
+
 };
 
 #include "base.hxx"

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -93,7 +93,6 @@ private:
 protected:
     //! @brief Throw a ReceivedSignal exception if SIGINT was received.
     static void throw_if_sigint_received();
-
 };
 
 #include "base.hxx"

--- a/include/time_series/internal/specialized_classes.hpp
+++ b/include/time_series/internal/specialized_classes.hpp
@@ -160,7 +160,8 @@ public:
     }
     std::string get_serialized(int index)
     {
-      throw std::logic_error("function not implemented for non multiprocess time series");      
+        throw std::logic_error(
+            "function not implemented for non multiprocess time series");
     }
     void set(int index, const T &t)
     {
@@ -193,7 +194,7 @@ public:
     }
     std::string get_serialized(int index)
     {
-      return a_.get_serialized(index);
+        return a_.get_serialized(index);
     }
     void set(int index, const T &t)
     {

--- a/include/time_series/internal/specialized_classes.hpp
+++ b/include/time_series/internal/specialized_classes.hpp
@@ -158,6 +158,10 @@ public:
     {
         t = v_[index];
     }
+    std::string get_serialized(int index)
+    {
+      throw std::logic_error("function not implemented for non multiprocess time series");      
+    }
     void set(int index, const T &t)
     {
         v_[index] = t;
@@ -186,6 +190,10 @@ public:
     void get(int index, T &t)
     {
         a_.get(index, t);
+    }
+    std::string get_serialized(int index)
+    {
+      return a_.get_serialized(index);
     }
     void set(int index, const T &t)
     {

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -185,32 +185,31 @@ public:
 
     /**
      * similar to the random access operator, but does not deserialized the
-     * accessed element. If the element is of a fundamental type (or an array of),
-     * an std::logic_error is thrown.
+     * accessed element. If the element is of a fundamental type (or an array
+     * of), an std::logic_error is thrown.
      */
-    std::string get_raw(const Index &timeindex)
+    std::string get_raw(const Index& timeindex)
     {
-      internal::Lock<internal::MultiProcesses> lock(*this->mutex_ptr_);
-      read_indexes();
-      if (timeindex < this->oldest_timeindex_)
-	{
-	  throw std::invalid_argument(
-				      "you tried to access time_series element which is too old.");
-	}
-      
-      while (this->newest_timeindex_ < timeindex)
-	{
-	  this->throw_if_sigint_received();
-	  
-	  this->condition_ptr_->wait(lock);
-	  read_indexes();
-	}
-      
-      return this->history_elements_ptr_->get_serialized(
-				       timeindex % this->history_elements_ptr_->size());
-      
+        internal::Lock<internal::MultiProcesses> lock(*this->mutex_ptr_);
+        read_indexes();
+        if (timeindex < this->oldest_timeindex_)
+        {
+            throw std::invalid_argument(
+                "you tried to access time_series element which is too old.");
+        }
+
+        while (this->newest_timeindex_ < timeindex)
+        {
+            this->throw_if_sigint_received();
+
+            this->condition_ptr_->wait(lock);
+            read_indexes();
+        }
+
+        return this->history_elements_ptr_->get_serialized(
+            timeindex % this->history_elements_ptr_->size());
     }
-  
+
 protected:
     void read_indexes()
     {

--- a/tests/test_basic_api.cpp
+++ b/tests/test_basic_api.cpp
@@ -126,10 +126,9 @@ TEST(time_series_ut, get_raw)
     std::string serialized = ts2.get_raw(index2);
     shared_memory::Serializer<Type> serializer;
     Type type2;
-    serializer.deserialize(serialized,type2);
-    ASSERT_EQ(type1,type2);
+    serializer.deserialize(serialized, type2);
+    ASSERT_EQ(type1, type2);
 }
-
 
 TEST(time_series_ut, full_round)
 {

--- a/tests/test_basic_api.cpp
+++ b/tests/test_basic_api.cpp
@@ -114,6 +114,23 @@ TEST(time_series_ut, serialized_multi_processes)
     ASSERT_EQ(type1, type2);
 }
 
+TEST(time_series_ut, get_raw)
+{
+    clear_memory(SEGMENT_ID);
+    typedef MultiprocessTimeSeries<Type> Mpt;
+    Mpt ts1 = Mpt::create_leader(SEGMENT_ID, 100);
+    Mpt ts2 = Mpt::create_follower(SEGMENT_ID);
+    Type type1;
+    ts1.append(type1);
+    Index index2 = ts2.newest_timeindex();
+    std::string serialized = ts2.get_raw(index2);
+    shared_memory::Serializer<Type> serializer;
+    Type type2;
+    serializer.deserialize(serialized,type2);
+    ASSERT_EQ(type1,type2);
+}
+
+
 TEST(time_series_ut, full_round)
 {
     clear_memory(SEGMENT_ID);


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Added a get_raw function, which is similar to the random access operation, except that the serialized version of the element is returned (if non multiprocess time series, or non serialized element multiprocess time series, std::logic_error thrown).
This could be used by loggers, to save directly serialized elements in files.

## How I Tested

unit test added

## Do not merge before

https://github.com/machines-in-motion/shared_memory/pull/25

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
