### PR TITLE
Make all getter methods const

### DIFF
--- a/include/time_series/interface.hpp
+++ b/include/time_series/interface.hpp
@@ -43,40 +43,40 @@ public:
      * If argument wait is false and the time series is empty,
      * returns time_series::EMPTY immediately.
      */
-    virtual Index newest_timeindex(bool wait = true) = 0;
+    virtual Index newest_timeindex(bool wait = true) const = 0;
 
     /*! \brief returns the number of element that has been contained in the
      * queue, i.e.
      *  the number of elements that have been added from the start.
      */
-    virtual Index count_appended_elements() = 0;
+    virtual Index count_appended_elements() const = 0;
 
     /*! \brief returns \f$ oldest \f$. waits if the time_series is empty.
      * If argument wait is false and the time series is empty,
      * returns time_series::EMPTY immediately.
      */
-    virtual Index oldest_timeindex(bool wait = true) = 0;
+    virtual Index oldest_timeindex(bool wait = true) const = 0;
 
     /*! \brief returns \f$ X_{newest} \f$. waits if the time_series is empty.
      */
-    virtual T newest_element() = 0;
+    virtual T newest_element() const = 0;
 
     /*! \brief returns \f$ X_{timeindex} \f$. waits if the time_series is empty
      * or if \f$timeindex > newest \f$.
      */
-    virtual T operator[](const Index &timeindex) = 0;
+    virtual T operator[](const Index &timeindex) const = 0;
 
     /*! \brief returns the time in miliseconds when \f$ X_{timeindex} \f$
      * was appended. Waits if the time_series is empty
      * or if \f$timeindex > newest \f$.
      */
-    virtual Timestamp timestamp_ms(const Index &timeindex) = 0;
+    virtual Timestamp timestamp_ms(const Index &timeindex) const = 0;
 
     /*! \brief returns the time in seconds when \f$ X_{timeindex} \f$
      * was appended. Waits if the time_series is empty
      * or if \f$timeindex > newest \f$.
      */
-    virtual Timestamp timestamp_s(const Index &timeindex) = 0;
+    virtual Timestamp timestamp_s(const Index &timeindex) const = 0;
 
     /*! \brief Wait until the defined time index is reached. If the input time
      * is below the oldest time index that have been registered read an
@@ -85,22 +85,22 @@ public:
     virtual bool wait_for_timeindex(
         const Index &timeindex,
         const double &max_duration_s =
-            std::numeric_limits<double>::quiet_NaN()) = 0;
+            std::numeric_limits<double>::quiet_NaN()) const = 0;
 
     /*! \brief returns the length of the time_series, i.e. \f$0\f$ if it is
      * empty, otherwise \f$newest - oldest +1 \f$.
      */
-    virtual std::size_t length() = 0;
+    virtual std::size_t length() const = 0;
 
     /** @brief returns the maximum length of the time serie.
      *  @return std::size_t
      */
-    virtual std::size_t max_length() = 0;
+    virtual std::size_t max_length() const = 0;
 
     /*! \brief returns boolean indicating whether new elements have been
      * appended since the last time the tag() function was called.
      */
-    virtual bool has_changed_since_tag() = 0;
+    virtual bool has_changed_since_tag() const = 0;
 
     /*! \brief tags the current time_series, can later be used to check
      * whether new elements have been added
@@ -110,7 +110,7 @@ public:
     /*! \brief returns the index at which the time series has been tagged.
      * Returns the newest timeindex if the time series has never been tagged.
      */
-    virtual Index tagged_timeindex() = 0;
+    virtual Index tagged_timeindex() const = 0;
 
     /*! \brief appends a new element to the time_series, e.g. we go from
      * \f$ X_{1:10} \f$ to \f$ X_{1:11} \f$ (where \f$ X_{11}=\f$ element).
@@ -124,6 +124,6 @@ public:
     /*! \brief returns true if no element has ever been appended
      *  to the time series.
      */
-    virtual bool is_empty() = 0;
+    virtual bool is_empty() const = 0;
 };
 }  // namespace time_series

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -33,23 +33,23 @@ public:
     TimeSeriesBase(Index start_timeindex = 0);
     TimeSeriesBase(TimeSeriesBase<P, T> &&other) noexcept;
     ~TimeSeriesBase();
-    Index newest_timeindex(bool wait = true);
-    Index count_appended_elements();
-    Index oldest_timeindex(bool wait = false);
-    T newest_element();
-    T operator[](const Index &timeindex);
-    Timestamp timestamp_ms(const Index &timeindex);
-    Timestamp timestamp_s(const Index &timeindex);
+    Index newest_timeindex(bool wait = true) const;
+    Index count_appended_elements() const;
+    Index oldest_timeindex(bool wait = false) const;
+    T newest_element() const;
+    T operator[](const Index &timeindex) const;
+    Timestamp timestamp_ms(const Index &timeindex) const;
+    Timestamp timestamp_s(const Index &timeindex) const;
     bool wait_for_timeindex(const Index &timeindex,
                             const double &max_duration_s =
-                                std::numeric_limits<double>::quiet_NaN());
-    size_t length();
-    size_t max_length();
-    bool has_changed_since_tag();
+                                std::numeric_limits<double>::quiet_NaN()) const;
+    size_t length() const;
+    size_t max_length() const;
+    bool has_changed_since_tag() const;
     void tag(const Index &timeindex);
-    Index tagged_timeindex();
+    Index tagged_timeindex() const;
     void append(const T &element);
-    bool is_empty();
+    bool is_empty() const;
 
 protected:
     // in case of multiprocesses: will be used to keep
@@ -66,7 +66,7 @@ protected:
     // non shared variable. initialized at true,
     // and switched to false when an element is observed
     // in the time series. Used only in the "is_empty" method.
-    bool empty_;
+    mutable bool empty_;
 
 protected:
     // see specialized_classes.hpp for

--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -54,13 +54,13 @@ public:
 protected:
     // in case of multiprocesses: will be used to keep
     // indexes values aligned for all instances
-    virtual void read_indexes() = 0;
+    virtual void read_indexes() const = 0;
     virtual void write_indexes() = 0;
 
-    Index start_timeindex_;
-    Index oldest_timeindex_;
-    Index newest_timeindex_;
-    Index tagged_timeindex_;
+    mutable Index start_timeindex_;
+    mutable Index oldest_timeindex_;
+    mutable Index newest_timeindex_;
+    mutable Index tagged_timeindex_;
 
 protected:
     // non shared variable. initialized at true,

--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -60,7 +60,7 @@ void TimeSeriesBase<P, T>::tag(const Index& timeindex)
 }
 
 template <typename P, typename T>
-Index TimeSeriesBase<P, T>::tagged_timeindex()
+Index TimeSeriesBase<P, T>::tagged_timeindex() const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -68,7 +68,7 @@ Index TimeSeriesBase<P, T>::tagged_timeindex()
 }
 
 template <typename P, typename T>
-bool TimeSeriesBase<P, T>::has_changed_since_tag()
+bool TimeSeriesBase<P, T>::has_changed_since_tag() const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -76,7 +76,7 @@ bool TimeSeriesBase<P, T>::has_changed_since_tag()
 }
 
 template <typename P, typename T>
-Index TimeSeriesBase<P, T>::newest_timeindex(bool wait)
+Index TimeSeriesBase<P, T>::newest_timeindex(bool wait) const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -101,7 +101,7 @@ Index TimeSeriesBase<P, T>::newest_timeindex(bool wait)
 }
 
 template <typename P, typename T>
-Index TimeSeriesBase<P, T>::count_appended_elements()
+Index TimeSeriesBase<P, T>::count_appended_elements() const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -109,7 +109,7 @@ Index TimeSeriesBase<P, T>::count_appended_elements()
 }
 
 template <typename P, typename T>
-Index TimeSeriesBase<P, T>::oldest_timeindex(bool wait)
+Index TimeSeriesBase<P, T>::oldest_timeindex(bool wait) const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -135,14 +135,14 @@ Index TimeSeriesBase<P, T>::oldest_timeindex(bool wait)
 }
 
 template <typename P, typename T>
-T TimeSeriesBase<P, T>::newest_element()
+T TimeSeriesBase<P, T>::newest_element() const
 {
     Index timeindex = newest_timeindex();
     return (*this)[timeindex];
 }
 
 template <typename P, typename T>
-T TimeSeriesBase<P, T>::operator[](const Index& timeindex)
+T TimeSeriesBase<P, T>::operator[](const Index& timeindex) const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -168,7 +168,7 @@ T TimeSeriesBase<P, T>::operator[](const Index& timeindex)
 }
 
 template <typename P, typename T>
-Timestamp TimeSeriesBase<P, T>::timestamp_ms(const Index& timeindex)
+Timestamp TimeSeriesBase<P, T>::timestamp_ms(const Index& timeindex) const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -194,14 +194,14 @@ Timestamp TimeSeriesBase<P, T>::timestamp_ms(const Index& timeindex)
 }
 
 template <typename P, typename T>
-Timestamp TimeSeriesBase<P, T>::timestamp_s(const Index& timeindex)
+Timestamp TimeSeriesBase<P, T>::timestamp_s(const Index& timeindex) const
 {
     return timestamp_ms(timeindex) / 1000.;
 }
 
 template <typename P, typename T>
-bool TimeSeriesBase<P, T>::wait_for_timeindex(const Index& timeindex,
-                                              const double& max_duration_s)
+bool TimeSeriesBase<P, T>::wait_for_timeindex(
+    const Index& timeindex, const double& max_duration_s) const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -259,7 +259,7 @@ void TimeSeriesBase<P, T>::append(const T& element)
 }
 
 template <typename P, typename T>
-size_t TimeSeriesBase<P, T>::length()
+size_t TimeSeriesBase<P, T>::length() const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -267,7 +267,7 @@ size_t TimeSeriesBase<P, T>::length()
 }
 
 template <typename P, typename T>
-size_t TimeSeriesBase<P, T>::max_length()
+size_t TimeSeriesBase<P, T>::max_length() const
 {
     Lock<P> lock(*this->mutex_ptr_);
     read_indexes();
@@ -275,7 +275,7 @@ size_t TimeSeriesBase<P, T>::max_length()
 }
 
 template <typename P, typename T>
-bool TimeSeriesBase<P, T>::is_empty()
+bool TimeSeriesBase<P, T>::is_empty() const
 {
     if (!empty_)
     {

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -211,7 +211,7 @@ public:
     }
 
 protected:
-    void read_indexes()
+    void read_indexes() const
     {
         indexes_.get(0, this->start_timeindex_);
         indexes_.get(1, this->oldest_timeindex_);
@@ -261,7 +261,7 @@ protected:
         }
     }
 
-    shared_memory::array<Index> indexes_;
+    mutable shared_memory::array<Index> indexes_;
 };
 
 /**

--- a/include/time_series/time_series.hpp
+++ b/include/time_series/time_series.hpp
@@ -50,7 +50,7 @@ public:
     }
 
 protected:
-    void read_indexes()
+    void read_indexes() const
     {
     }
     void write_indexes()


### PR DESCRIPTION
## Description

Make all getter methods `const`.

For this, `read_indexes()` needs to be const as well, which writes some index variables in the multi process time series.  To make this work, I marked those variables as `mutable`.  I'm not sure if this is the best solution, maybe there is another way?

For context why this is needed: I started replacing the deprecated `real_time_tools::ThreadsafeTimeseries` with `time_series::TimeSeries` in the blmc_drivers package.  However, it is used there in a lot of const methods so the called methods of the time series should be const as well.

## How I Tested

Testing both single-process and multi-process time series with robot_interfaces (using simulation backend).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
