### PR TITLE
Add option to not throw exception on SIGINT

### DIFF
--- a/include/time_series/internal/base.hpp
+++ b/include/time_series/internal/base.hpp
@@ -30,7 +30,15 @@ template <typename P, typename T = int>
 class TimeSeriesBase : public TimeSeriesInterface<T>
 {
 public:
-    TimeSeriesBase(Index start_timeindex = 0);
+    /**
+     * @brief Constructor.
+     *
+     * @param start_timeindex  Time index of the first element.
+     * @param throw_on_sigint  If true, a signal_handler::ReceivedSignal
+     *     exception is thrown when a SIGINT signal is received while waiting in
+     *     one of the getter methods.
+     */
+    TimeSeriesBase(Index start_timeindex = 0, bool throw_on_sigint = true);
     TimeSeriesBase(TimeSeriesBase<P, T> &&other) noexcept;
     ~TimeSeriesBase();
     Index newest_timeindex(bool wait = true) const;
@@ -82,6 +90,10 @@ private:
     //! Set to true in destructor to indicate thread that it should terminate.
     std::atomic<bool> is_destructor_called_;
 
+    //! If true an exception is thrown if a SIGINT is received while waiting in
+    //! one of the methods.
+    bool throw_on_sigint_;
+
     /**
      * @brief Monitors if SIGINT was received and releases the lock if yes.
      *
@@ -92,7 +104,7 @@ private:
 
 protected:
     //! @brief Throw a ReceivedSignal exception if SIGINT was received.
-    static void throw_if_sigint_received();
+    void throw_if_sigint_received() const;
 };
 
 #include "base.hxx"

--- a/include/time_series/time_series.hpp
+++ b/include/time_series/time_series.hpp
@@ -35,8 +35,11 @@ template <typename T = int>
 class TimeSeries : public internal::TimeSeriesBase<internal::SingleProcess, T>
 {
 public:
-    TimeSeries(size_t max_length, Index start_timeindex = 0)
-        : internal::TimeSeriesBase<internal::SingleProcess, T>(start_timeindex)
+    TimeSeries(size_t max_length,
+               Index start_timeindex = 0,
+               bool throw_on_sigint = true)
+        : internal::TimeSeriesBase<internal::SingleProcess, T>(start_timeindex,
+                                                               throw_on_sigint)
     {
         this->mutex_ptr_ =
             std::make_shared<internal::Mutex<internal::SingleProcess> >();


### PR DESCRIPTION
## Description

There might be cases where basically killing the time series on a SIGINT is not desirable (e.g. when it is needed to perform some shutdown procedure).  Therefore add an option `throw_on_sigint` (which defaults to the current behaviour).

I stumbled upon this issue when replacing the old real_time_tools-time-series in blmc_drivers with the one from this package.  There the exception causes an "terminate called recursively" error and as a consequence the robot is not shut down cleanly.

While this works, I'm not convinced that it is the nicest solution so I'd like to hear your opinion.


## How I Tested

Together with a feature branch on blmc_drivers, using the time series there instead of the old one from real_time_tools.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
