### PR TITLE
create_leader/follower exit only for MultiprocessTimeSeries

### DIFF
--- a/include/time_series/pybind11_helper.hxx
+++ b/include/time_series/pybind11_helper.hxx
@@ -11,10 +11,6 @@ void __create_python_bindings(pybind11::module& m, const std::string& classname)
     // (maybe some issue with the move copy of the shared memory condition
     // variable)
 
-    std::string leader = std::string("create_leader_") + classname;
-    std::string follower = std::string("create_follower_") + classname;
-    m.def(leader.c_str(), &TS::create_leader_ptr);
-    m.def(follower.c_str(), &TS::create_follower_ptr);
     pybind11::class_<TS, std::shared_ptr<TS>>(m, classname.c_str())
         .def("newest_timeindex", &TS::newest_timeindex)
         .def("count_appended_elements", &TS::count_appended_elements)
@@ -45,6 +41,11 @@ void _create_python_bindings(pybind11::module& m, const std::string& classname)
     {
         typedef time_series::MultiprocessTimeSeries<T> TS;
         __create_python_bindings<TS>(m, classname);
+
+        std::string leader = std::string("create_leader_") + classname;
+        std::string follower = std::string("create_follower_") + classname;
+        m.def(leader.c_str(), &TS::create_leader_ptr);
+        m.def(follower.c_str(), &TS::create_follower_ptr);
         m.def("clear_memory", &time_series::clear_memory);
     }
 }


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The methods `create_leader_ptr` and `create_follower_ptr` only exit for
the `MultiprocessTimeSeries`, so using the binding function for a single
process TimeSeries resulted in a build error.


## How I Tested

Built a package that adds Python bindings for both the single- and multi-process version of the time series.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
