### PR TITLE
Set argument default value in Python bindings

### DIFF
--- a/include/time_series/pybind11_helper.hxx
+++ b/include/time_series/pybind11_helper.hxx
@@ -12,13 +12,21 @@ void __create_python_bindings(pybind11::module& m, const std::string& classname)
     // variable)
 
     pybind11::class_<TS, std::shared_ptr<TS>>(m, classname.c_str())
-        .def("newest_timeindex", &TS::newest_timeindex)
+        .def("newest_timeindex",
+             &TS::newest_timeindex,
+             pybind11::arg("wait") = true)
         .def("count_appended_elements", &TS::count_appended_elements)
-        .def("oldest_timeindex", &TS::oldest_timeindex)
+        .def("oldest_timeindex",
+             &TS::oldest_timeindex,
+             pybind11::arg("wait") = true)
         .def("newest_element", &TS::newest_element)
         .def("timestamp_ms", &TS::timestamp_ms)
         .def("timestamp_s", &TS::timestamp_s)
-        .def("wait_for_timeindex", &TS::wait_for_timeindex)
+        .def("wait_for_timeindex",
+             &TS::wait_for_timeindex,
+             pybind11::arg("timeindex"),
+             pybind11::arg("max_duration_s") =
+                 std::numeric_limits<double>::quiet_NaN())
         .def("length", &TS::length)
         .def("max_length", &TS::max_length)
         .def("has_changed_since_tag", &TS::has_changed_since_tag)


### PR DESCRIPTION
## Description

Set the default values of method arguments in the Python bindings.

## How I Tested

By using `wait_for_timeindex` without specifying a timout.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
