### PR TITLE
Provide more information in error messages

### DIFF
--- a/include/time_series/internal/base.hxx
+++ b/include/time_series/internal/base.hxx
@@ -156,8 +156,10 @@ T TimeSeriesBase<P, T>::operator[](const Index& timeindex) const
     read_indexes();
     if (timeindex < oldest_timeindex_)
     {
-        throw std::invalid_argument(
-            "you tried to access time_series element which is too old.");
+        throw std::invalid_argument("you tried to access time_series element " +
+                                    std::to_string(timeindex) +
+                                    " which is too old (oldest in buffer is " +
+                                    std::to_string(oldest_timeindex_) + ").");
     }
 
     while (newest_timeindex_ < timeindex)
@@ -182,8 +184,10 @@ Timestamp TimeSeriesBase<P, T>::timestamp_ms(const Index& timeindex) const
     read_indexes();
     if (timeindex < oldest_timeindex_)
     {
-        throw std::invalid_argument(
-            "you tried to access time_series element which is too old.");
+        throw std::invalid_argument("you tried to access time_series element " +
+                                    std::to_string(timeindex) +
+                                    " which is too old (oldest in buffer is " +
+                                    std::to_string(oldest_timeindex_) + ").");
     }
 
     while (newest_timeindex_ < timeindex)
@@ -215,8 +219,10 @@ bool TimeSeriesBase<P, T>::wait_for_timeindex(
     read_indexes();
     if (timeindex < oldest_timeindex_)
     {
-        throw std::invalid_argument(
-            "you tried to access time_series element which is too old.");
+        throw std::invalid_argument("you tried to access time_series element " +
+                                    std::to_string(timeindex) +
+                                    " which is too old (oldest in buffer is " +
+                                    std::to_string(oldest_timeindex_) + ").");
     }
 
     while (newest_timeindex_ < timeindex)

--- a/include/time_series/multiprocess_time_series.hpp
+++ b/include/time_series/multiprocess_time_series.hpp
@@ -195,7 +195,10 @@ public:
         if (timeindex < this->oldest_timeindex_)
         {
             throw std::invalid_argument(
-                "you tried to access time_series element which is too old.");
+                "you tried to access time_series element " +
+                std::to_string(timeindex) +
+                " which is too old (oldest in buffer is " +
+                std::to_string(this->oldest_timeindex_) + ").");
         }
 
         while (this->newest_timeindex_ < timeindex)

--- a/tests/test_basic_api.cpp
+++ b/tests/test_basic_api.cpp
@@ -17,7 +17,6 @@
 using namespace real_time_tools;
 using namespace time_series;
 
-
 TEST(time_series_ut, basic)
 {
     TimeSeries<int> ts1(100);
@@ -95,7 +94,6 @@ TEST(time_series_ut, factories)
     ASSERT_EQ(follower2.newest_timeindex(), start_timeindex);
 }
 
-
 TEST(time_series_ut, serialized_multi_processes)
 {
     clear_memory(SEGMENT_ID);
@@ -111,9 +109,8 @@ TEST(time_series_ut, serialized_multi_processes)
     Index index2 = ts2.newest_timeindex();
     ASSERT_EQ(index1, index2);
     Type type2 = ts2[index2];
-    ASSERT_TRUE(type1==type2);
+    ASSERT_TRUE(type1 == type2);
 }
-
 
 TEST(time_series_ut, get_raw)
 {
@@ -128,7 +125,7 @@ TEST(time_series_ut, get_raw)
     shared_memory::Serializer<Type> serializer;
     Type type2;
     serializer.deserialize(serialized, type2);
-    ASSERT_TRUE(type1==type2);
+    ASSERT_TRUE(type1 == type2);
 }
 
 TEST(time_series_ut, full_round)
@@ -152,7 +149,7 @@ TEST(time_series_ut, full_round)
 
     Type type1 = ts1[index1];
     Type type2 = ts2[index2];
-    ASSERT_TRUE(type1==type2);
+    ASSERT_TRUE(type1 == type2);
 }
 
 void *add_element(void *args)
@@ -189,7 +186,6 @@ TEST(time_series_ut, newest_index_no_wait)
     ASSERT_EQ(index, -1);
 }
 
-
 void *add_element_mp(void *)
 {
     typedef MultiprocessTimeSeries<Type> Mpt;
@@ -224,8 +220,6 @@ TEST(time_series_ut, count_appended_elements)
     ASSERT_EQ(count, 205);
 }
 
-
-
 void *to_time_index(void *)
 {
     typedef MultiprocessTimeSeries<int> Mpt;
@@ -242,8 +236,6 @@ void *to_time_index(void *)
     }
     return nullptr;
 }
-
-
 
 TEST(time_series_ut, wait_for_time_index)
 {
@@ -308,4 +300,3 @@ TEST(time_series_ut, multi_processes_empty)
     ASSERT_FALSE(ts1.is_empty());
     ASSERT_FALSE(ts2.is_empty());
 }
-


### PR DESCRIPTION
## Description

For debugging the error, it can be helpful to see what the actual values of desired and oldest timeindex are, so add them to the error messages.

Also do some reformatting (via mpi_cpp_format).


## How I Tested

By running it in a situation where one of these exceptions was thrown.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
