### PR TITLE
Bump version to 2.1.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [Unreleased]
+
+## [2.1.0] - 2022-06-29
+### Added
+- Optional argument to not throw an exception on SIGINT.
+- Set argument default values in Python bindings
+
+### Fixed
+- Build error when using Python binding function for single process time series.
+
+
+## [2.0.0] - 2021-03-02
+
+There is no changelog for this or earlier versions.
+
+
+[Unreleased]: https://github.com/machines-in-motion/time_series/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/machines-in-motion/time_series/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/machines-in-motion/time_series/releases/tag/v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+The format of this changelog is based on 
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
 ## [Unreleased]
 
 ## [2.1.0] - 2022-06-29

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(time_series VERSION 2.0.0)
+project(time_series VERSION 2.1.0)
 
 # Using C++17
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
## Description

Bump version to 2.1.0 and add a changelog (following the format suggested by https://keepachangelog.com/en/1.0.0/).

In preparation for the upcoming Real Robot Challenge 2022, I'm making versioned releases of our packages and use the occasion to add proper changelog files.